### PR TITLE
Added support for deployment slots. 

### DIFF
--- a/Start/Start.ps1
+++ b/Start/Start.ps1
@@ -10,18 +10,43 @@ param
     $ConnectedServiceNameARM,
 
     [String] [Parameter(Mandatory = $true)]
-    $WebAppName
+    $WebAppName,
+
+    [String]
+    $Slotname
 )
 
-Write-Verbose "Init Start task"
+Write-Host "Init Start task"
 
-Write-Verbose "ConnectedServiceNameSelector = $ConnectedServiceNameSelector"
-Write-Verbose "ConnectedServiceName = $ConnectedServiceName"
-Write-Verbose "ConnectedServiceNameARM = $ConnectedServiceNameARM"
-Write-Verbose "WebAppName = $WebAppName"
+Write-Host "ConnectedServiceNameSelector = $ConnectedServiceNameSelector"
+Write-Host "ConnectedServiceName = $ConnectedServiceName"
+Write-Host "ConnectedServiceNameARM = $ConnectedServiceNameARM"
+Write-Host "WebAppName = $WebAppName"
 
-##Initialize-Azure
-$website = Get-AzureWebsite -Name $WebAppName
-Start-AzureWebsite -Name $WebAppName
+# using production slot for website if website name provided does not contain any slot
+# supports using slot explicitally, or using slot in app name or supplying no slot.
+if ([String]::IsNullOrEmpty($Slotname))
+{
+    if($WebAppName -notlike '*(*)*')
+    {
+        $Slotname  = 'Production'
+    }
+}
 
-Write-Verbose "Ending Start task"
+Write-Host "Slot = $Slotname"
+
+if ($Slotname){
+    # Slot has been specified
+    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName -Slot $Slotname"
+    $website = Get-AzureWebsite -Name $WebAppName -Slot $Slotname
+    Write-Host "##[command]Start-AzureWebsite -Name $WebAppName -Slot $Slotname"
+    Start-AzureWebsite -Name $WebAppName -Slot $Slotname
+}else{
+    # This case the app name contains the slot details
+    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName"
+    $website = Get-AzureWebsite -Name $WebAppName
+    Write-Host "##[command]Start-AzureWebsite -Name $WebAppName"
+    Start-AzureWebsite -Name $WebAppName
+}
+
+Write-Host "Ending Start task"

--- a/Start/task.json
+++ b/Start/task.json
@@ -11,13 +11,13 @@
     "author": "rbengtsson",
     "version": {
         "Major": 0,
-        "Minor": 2,
-        "Patch": 5
+        "Minor": 3,
+        "Patch": 0
     },
 	"demands": [
 		"azureps"
 	],
-    "minimumAgentVersion": "1.101.2",
+    "minimumAgentVersion": "1.95.3",
     "groups": [
         {
             "name": "advanced",
@@ -63,6 +63,14 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "Enter the name of an existing Azure App Service Application."
+        },
+        {
+            "name": "Slot",
+            "type": "string",
+            "label": "Slot",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Enter the name of the deployment slot you wish to deploy to (optional)."
         }
     ],
 	"execution": {

--- a/Stop/Stop.ps1
+++ b/Stop/Stop.ps1
@@ -10,18 +10,43 @@ param
     $ConnectedServiceNameARM,
 
     [String] [Parameter(Mandatory = $true)]
-    $WebAppName
+    $WebAppName,
+    
+    [String]
+    $Slotname
 )
 
-Write-Verbose "Init Stop task"
+Write-Host "Init Stop task"
 
-Write-Verbose "ConnectedServiceNameSelector = $ConnectedServiceNameSelector"
-Write-Verbose "ConnectedServiceName = $ConnectedServiceName"
-Write-Verbose "ConnectedServiceNameARM = $ConnectedServiceNameARM"
-Write-Verbose "WebAppName = $WebAppName"
+Write-Host "ConnectedServiceNameSelector = $ConnectedServiceNameSelector"
+Write-Host "ConnectedServiceName = $ConnectedServiceName"
+Write-Host "ConnectedServiceNameARM = $ConnectedServiceNameARM"
+Write-Host "WebAppName = $WebAppName"
 
-##Initialize-Azure
-$website = Get-AzureWebsite -Name $WebAppName
-Stop-AzureWebsite -Name $WebAppName
+# using production slot for website if website name provided does not contain any slot
+# supports using slot explicitally, or using slot in app name or supplying no slot.
+if ([String]::IsNullOrEmpty($Slotname))
+{
+    if($WebAppName -notlike '*(*)*')
+    {
+        $Slotname  = 'Production'
+    }
+}
 
-Write-Verbose "Ending Stop task"
+Write-Host "Slot = $Slotname"
+
+if ($Slotname){
+    # Slot has been specified
+    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName -Slot $Slotname"
+    $website = Get-AzureWebsite -Name $WebAppName -Slot $Slotname
+    Write-Host "##[command]Stop-AzureWebsite -Name $WebAppName -Slot $Slotname"
+    Stop-AzureWebsite -Name $WebAppName -Slot $Slotname
+}else{
+    # This case the app name contains the slot details
+    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName"
+    $website = Get-AzureWebsite -Name $WebAppName
+    Write-Host "##[command]Stop-AzureWebsite -Name $WebAppName"
+    Stop-AzureWebsite -Name $WebAppName
+}
+
+Write-Host "Ending Stop task"

--- a/Stop/task.json
+++ b/Stop/task.json
@@ -11,13 +11,13 @@
     "author": "rbengtsson",
     "version": {
         "Major": 0,
-        "Minor": 2,
-        "Patch": 5
+        "Minor": 3,
+        "Patch": 0
     },
 	"demands": [
 		"azureps"
 	],
-    "minimumAgentVersion": "1.101.2",
+    "minimumAgentVersion": "1.95.3",
     "groups": [
         {
             "name": "advanced",
@@ -63,6 +63,14 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "Enter the name of an existing Azure App Service Application."
+        },
+        {
+            "name": "Slot",
+            "type": "string",
+            "label": "Slot",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Enter the name of the deployment slot you wish to deploy to (optional)."
         }
     ],  
 	"execution": {

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,1 @@
+tfx extension create --manifest-globs vss-extension.json

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "appservices-start-stop",
-    "version": "0.2.5",
+    "version": "0.3.0",
     "name": "Azure App Services - Start and Stop",
     "description": "Tasks for starting and stopping an Azure App Service as a part of a VSTS build",
     "public": true,


### PR DESCRIPTION
I have added support for deployment slots.  I have also done the following:
- Added a convenience build.cmd file.  Feel free to remove this if you don't want it.
- Incremented the version numbers of both tasks in accordance to SemVer.
- Reduced the minimumAgentVersion to 1.95.3.  This is because that is the highest version for on-premise TFS users.  I don't see why it couldn't be reduced further, I don't see anything in the task that requires such a high version.  But maybe I'm missing something.
