### PR TITLE
Added support for ARM connection type

### DIFF
--- a/Start/Start.ps1
+++ b/Start/Start.ps1
@@ -35,18 +35,41 @@ if ([String]::IsNullOrEmpty($Slotname))
 
 Write-Host "Slot = $Slotname"
 
-if ($Slotname){
-    # Slot has been specified
-    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName -Slot $Slotname"
-    $website = Get-AzureWebsite -Name $WebAppName -Slot $Slotname
-    Write-Host "##[command]Start-AzureWebsite -Name $WebAppName -Slot $Slotname"
-    Start-AzureWebsite -Name $WebAppName -Slot $Slotname
-}else{
-    # This case the app name contains the slot details
-    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName"
-    $website = Get-AzureWebsite -Name $WebAppName
-    Write-Host "##[command]Start-AzureWebsite -Name $WebAppName"
-    Start-AzureWebsite -Name $WebAppName
+# Use ARM cmdlets with a ARM connected Service
+if($ConnectedServiceNameSelector -eq "ConnectedServiceNameARM")
+{
+    $resourceGroup = Get-AzureRmWebApp -Name $WebAppName | % { $_.ResourceGroup }
+    Write-Host "ResourceGroup = $resourceGroup"
+    
+    if ($Slotname) {
+        # Slot has been specified
+        Write-Host "##[command]Get-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname"
+        $website = Get-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname
+        Write-Host "##[command]Start-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname"
+        Start-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname
+    } else {
+        # This case the app name contains the slot details
+        Write-Host "##[command]Get-AzureRmWebApp -Name $WebAppName"
+        $website = Get-AzureRmWebApp -Name $WebAppName
+        Write-Host "##[command]Start-AzureRmWebApp -Name $WebAppName"
+        Start-AzureRmWebApp -Name $WebAppName
+    }
+}
+# Default to classic cmdlets if not otherwise specified
+else {
+    if ($Slotname) {
+        # Slot has been specified
+        Write-Host "##[command]Get-AzureWebsite -Name $WebAppName -Slot $Slotname"
+        $website = Get-AzureWebsite -Name $WebAppName -Slot $Slotname
+        Write-Host "##[command]Start-AzureWebsite -Name $WebAppName -Slot $Slotname"
+        Start-AzureWebsite -Name $WebAppName -Slot $Slotname
+    } else {
+        # This case the app name contains the slot details
+        Write-Host "##[command]Get-AzureWebsite -Name $WebAppName"
+        $website = Get-AzureWebsite -Name $WebAppName
+        Write-Host "##[command]Start-AzureWebsite -Name $WebAppName"
+        Start-AzureWebsite -Name $WebAppName
+    }
 }
 
 Write-Host "Ending Start task"

--- a/Stop/Stop.ps1
+++ b/Stop/Stop.ps1
@@ -25,7 +25,7 @@ Write-Host "WebAppName = $WebAppName"
 
 # using production slot for website if website name provided does not contain any slot
 # supports using slot explicitally, or using slot in app name or supplying no slot.
-if ([String]::IsNullOrEmpty($Slotname))
+if ([String]::IsNullOrEmpty($Slotname)) 
 {
     if($WebAppName -notlike '*(*)*')
     {
@@ -35,18 +35,41 @@ if ([String]::IsNullOrEmpty($Slotname))
 
 Write-Host "Slot = $Slotname"
 
-if ($Slotname){
-    # Slot has been specified
-    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName -Slot $Slotname"
-    $website = Get-AzureWebsite -Name $WebAppName -Slot $Slotname
-    Write-Host "##[command]Stop-AzureWebsite -Name $WebAppName -Slot $Slotname"
-    Stop-AzureWebsite -Name $WebAppName -Slot $Slotname
-}else{
-    # This case the app name contains the slot details
-    Write-Host "##[command]Get-AzureWebsite -Name $WebAppName"
-    $website = Get-AzureWebsite -Name $WebAppName
-    Write-Host "##[command]Stop-AzureWebsite -Name $WebAppName"
-    Stop-AzureWebsite -Name $WebAppName
+# Use ARM cmdlets with a ARM connected Service
+if($ConnectedServiceNameSelector -eq "ConnectedServiceNameARM")
+{
+    $resourceGroup = Get-AzureRmWebApp -Name $WebAppName | % { $_.ResourceGroup }
+    Write-Host "ResourceGroup = $resourceGroup"
+    
+    if ($Slotname) {
+        # Slot has been specified
+        Write-Host "##[command]Get-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname"
+        $website = Get-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname
+        Write-Host "##[command]Stop-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname"
+        Stop-AzureRmWebAppSlot -ResourceGroupName $resourceGroup -Name $WebAppName -Slot $Slotname
+    } else {
+        # This case the app name contains the slot details
+        Write-Host "##[command]Get-AzureRmWebApp -Name $WebAppName"
+        $website = Get-AzureRmWebApp -Name $WebAppName
+        Write-Host "##[command]Stop-AzureRmWebApp -Name $WebAppName"
+        Stop-AzureRmWebApp -Name $WebAppName
+    }
+}
+# Default to classic cmdlets if not otherwise specified
+else {
+    if ($Slotname) {
+        # Slot has been specified
+        Write-Host "##[command]Get-AzureWebsite -Name $WebAppName -Slot $Slotname"
+        $website = Get-AzureWebsite -Name $WebAppName -Slot $Slotname
+        Write-Host "##[command]Stop-AzureWebsite -Name $WebAppName -Slot $Slotname"
+        Stop-AzureWebsite -Name $WebAppName -Slot $Slotname
+    } else {
+        # This case the app name contains the slot details
+        Write-Host "##[command]Get-AzureWebsite -Name $WebAppName"
+        $website = Get-AzureWebsite -Name $WebAppName
+        Write-Host "##[command]Stop-AzureWebsite -Name $WebAppName"
+        Stop-AzureWebsite -Name $WebAppName
+    }
 }
 
 Write-Host "Ending Stop task"

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "appservices-start-stop",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "name": "Azure App Services - Start and Stop",
     "description": "Tasks for starting and stopping an Azure App Service as a part of a VSTS build",
     "public": true,


### PR DESCRIPTION
This PR adds support for the ARM connection type. 

If the user specifies Azure Resource Manager as the azure connection type, then the task will use the RM commands. Otherwise, there will be no be no change in functionality. This commit will allow users to use the Start/Stop tasks for RM resources while remaining backwards compatible for the classic applications.
